### PR TITLE
v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Changed
 ### Added
+- Added Release Dates to releases in CHANGELOG - @nickmoline
 
-## [v1.0.1]
+## [v1.0.1] - 2016-12-27
 ### Fixed
 - [#5](https://github.com/nickmoline/robots-checker/issues/5) Redirects not being followed and seen as a loop - @nickmoline
 ### Added
 - Added MIT License File [LICENSE.txt](https://github.com/nickmoline/robots-checker/blob/master/LICENSE.txt) (was already specified in composer.json)  - @nickmoline
 - Added [CONTRIBUTING.md](https://github.com/nickmoline/robots-checker/blob/master/CONTRIBUTING.md) for Contribution Instructions  - @nickmoline
 
-## [v1.0.0]
+## [v1.0.0] - 2016-12-26
 ### Added
 - Initial Commits of base project - @nickmoline
 - Classes for checking urls against various methods of robots exclusion - @nickmoline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 ### Added
 - Added Release Dates to releases in CHANGELOG - @nickmoline
+- Added getters and setters for Redirects and Original URL to `Robots\Status` - @nickmoline
 
 ## [v1.0.1] - 2016-12-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 ### Changed
+- Set explicit allowed reason in `Robots\Meta` if no META Robots tag is present - @nickmoline
+- Set explicit allowed reason in `Robots\Header` if no `X-Robots-Tag` HTTP Header is present - @nickmoline
 ### Added
 - Added Release Dates to releases in CHANGELOG - @nickmoline
 - Added getters and setters for Redirects and Original URL to `Robots\Status` - @nickmoline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
-### Fixed
+## [v1.0.2] - 2016-12-29
 ### Changed
+- Set explicit allowed reason in `Robots\Meta` if no META Robots tag is present - @nickmoline
+- Set explicit allowed reason in `Robots\Header` if no `X-Robots-Tag` HTTP Header is present - @nickmoline
 ### Added
+- Added getters and setters for Redirects and Original URL to `Robots\Status` - @nickmoline
+- Passed redirects and original url to `::createFromExisting` for `Robots\Status` - @nickmoline
 
-## [v1.0.1]
+## [v1.0.1] - 2016-12-27
 ### Fixed
 - [#5](https://github.com/nickmoline/robots-checker/issues/5) Redirects not being followed and seen as a loop - @nickmoline
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added Release Dates to releases in CHANGELOG - @nickmoline
 - Added getters and setters for Redirects and Original URL to `Robots\Status` - @nickmoline
+- Passed redirects and original url to `::createFromExisting` for `Robots\Status` - @nickmoline
 
 ## [v1.0.1] - 2016-12-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v1.0.2] - 2016-12-29
+## [Unreleased]
+### Fixed
 ### Changed
-- Set explicit allowed reason in `Robots\Meta` if no META Robots tag is present - @nickmoline
-- Set explicit allowed reason in `Robots\Header` if no `X-Robots-Tag` HTTP Header is present - @nickmoline
 ### Added
-- Added getters and setters for Redirects and Original URL to `Robots\Status` - @nickmoline
-- Passed redirects and original url to `::createFromExisting` for `Robots\Status` - @nickmoline
 
-## [v1.0.1] - 2016-12-27
+## [v1.0.1]
 ### Fixed
 - [#5](https://github.com/nickmoline/robots-checker/issues/5) Redirects not being followed and seen as a loop - @nickmoline
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
-### Fixed
+## [v1.0.2] - 2016-12-29
 ### Changed
 - Set explicit allowed reason in `Robots\Meta` if no META Robots tag is present - @nickmoline
 - Set explicit allowed reason in `Robots\Header` if no `X-Robots-Tag` HTTP Header is present - @nickmoline
@@ -27,5 +26,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - php-unit tests - @nickmoline
 
 [Unreleased]: https://github.com/nickmoline/robots-checker
+[v1.0.2]: https://github.com/nickmoline/robots-checker/releases/tag/v1.0.2
 [v1.0.1]: https://github.com/nickmoline/robots-checker/releases/tag/v1.0.1
 [v1.0.0]: https://github.com/nickmoline/robots-checker/releases/tag/v1.0.0

--- a/src/Header.php
+++ b/src/Header.php
@@ -31,6 +31,9 @@ class Header extends Status
 
         $headers = $this->getResponseHeaders();
         if (!isset($headers['X-Robots-Tag'])) {
+            if ($this->isAllowed()) {
+                $this->setReason("No X-Robots-Tag HTTP Header");
+            }
             return $this->isAllowed();
         }
 

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -45,6 +45,9 @@ class Meta extends Status
             return $this->globalAllowed;
         }
 
+        if ($this->isAllowed()) {
+            $this->setReason("No Meta Robots or Meta {$this->userAgent} Tag Present");
+        }
         return $this->isAllowed();
     }
 

--- a/src/Status.php
+++ b/src/Status.php
@@ -153,7 +153,7 @@ class Status extends RobotsBase
     private function processRedirect()
     {
         if (!isset($this->originalUrl)) {
-            $this->originalUrl = $this->url;
+            $this->setOriginalUrl($this->url);
         }
 
         if (count($this->redirects) > 10) {
@@ -164,5 +164,30 @@ class Status extends RobotsBase
         $this->redirects[] = "{$this->statusCode} {$redirectUrl}";
         $this->setURL($redirectUrl)->setNotFetched();
         return $this->validate();
+    }
+
+    public function getRedirects($includeOriginal = false)
+    {
+        $redirects = $this->redirects;
+        if ($includeOriginal) {
+            array_unshift($redirects, "Original URL: {$this->originalUrl}");
+        }
+
+        return $redirects;
+    }
+
+    public function setRedirects($redirects)
+    {
+        $this->redirects = $redirects;
+    }
+
+    public function getOriginalUrl()
+    {
+        return $this->originalUrl;
+    }
+
+    public function setOriginalUrl($url)
+    {
+        $this->originalUrl = $url;
     }
 }

--- a/src/Status.php
+++ b/src/Status.php
@@ -25,6 +25,8 @@ class Status extends RobotsBase
             $robots->setRequestHeaders($existing->getRequestHeaders())
                    ->setResponseHeaders($existing->getResponseHeaders())
                    ->setStatusCode($existing->getStatusCode())
+                   ->setOriginalUrl($existing->getOriginalUrl())
+                   ->setRedirects($existing->getRedirects())
                    ->setContents($existing->getContents());
         }
 


### PR DESCRIPTION
## [v1.0.2] - 2016-12-29
### Changed
- Set explicit allowed reason in `Robots\Meta` if no META Robots tag is present
- Set explicit allowed reason in `Robots\Header` if no `X-Robots-Tag` HTTP Header is present
### Added
- Added Release Dates to releases in CHANGELOG
- Added getters and setters for Redirects and Original URL to `Robots\Status`
- Passed redirects and original url to `::createFromExisting` for `Robots\Status`

[v1.0.2]: https://github.com/nickmoline/robots-checker/releases/tag/v1.0.2
